### PR TITLE
Using a bitwise complement to represent MinInt

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -3,4 +3,4 @@ package mmmdatastructures
 const MaxUint = ^uint(0)
 const MinUint = 0
 const MaxInt = int(MaxUint >> 1)
-const MinInt = -MaxInt - 1
+const MinInt = ^MaxInt


### PR DESCRIPTION
This PR changes the `MinInt` constant to use a [bitwise complement operator](https://en.wikipedia.org/wiki/Bitwise_operation#NOT), rather than a subtraction on a negative value.

This works because, [as per the Go spec on "Numeric Types"](https://golang.org/ref/spec#Numeric_types), integers are represented using two's complement arithmetic.

Working proof here: https://play.golang.org/p/KXoRGTGzb2.

(I used GitHub on-site editing for this file, something I basically never do... hence the `patch-1` branch name. 😃)